### PR TITLE
chore: improve code style

### DIFF
--- a/src/__tests__/migrator.test.ts
+++ b/src/__tests__/migrator.test.ts
@@ -42,7 +42,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
           'export const Test = defineComponent({})',
         ].join('\n'));
     });
@@ -56,7 +56,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
           'export default defineComponent({})',
         ].join('\n'));
     });
@@ -72,14 +72,14 @@ describe('migrateFile()', () => {
       expect(migratedFile.getText())
         .toBe([
           'import Bla, { Blo } from "./blabla"',
-          'import { defineComponent } from "~/lib/helper/fallback-composition-api";\n',
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
           'export default defineComponent({})',
         ].join('\n'));
     });
 
     test('Vue import respected', async () => {
       const sourceFile = createSourceFile([
-        'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
+        'import Vue, { mounted } from \'~/lib/helper/fallback-composition-api\';',
         '@Component',
         'export default class Test {}',
       ].join('\n'));
@@ -87,7 +87,7 @@ describe('migrateFile()', () => {
       const migratedFile = await migrateFile(project, sourceFile);
       expect(migratedFile.getText())
         .toBe([
-          'import Vue, { mounted, defineComponent } from "~/lib/helper/fallback-composition-api";',
+          'import Vue, { mounted, defineComponent } from \'~/lib/helper/fallback-composition-api\';',
           'export default defineComponent({})',
         ].join('\n'));
     });
@@ -95,7 +95,7 @@ describe('migrateFile()', () => {
     test('Vue import respected in .vue file', async () => {
       const sourceFile = createSourceFile([
         '<script lang="ts">',
-        'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
+        'import Vue, { mounted } from \'~/lib/helper/fallback-composition-api\';',
         '@Component',
         'export default class {}',
         '</script>',
@@ -105,10 +105,36 @@ describe('migrateFile()', () => {
       expect(migratedFile.getText())
         .toBe([
           '<script lang="ts">',
-          'import Vue, { mounted, defineComponent } from "~/lib/helper/fallback-composition-api";',
+          'import Vue, { mounted, defineComponent } from \'~/lib/helper/fallback-composition-api\';',
           'export default defineComponent({})',
           '',
           '</script>',
+        ].join('\n'));
+    });
+  });
+
+  describe('Code styles', () => {
+    test('Single quotation and 2 spaces indentation', async () => {
+      const sourceFile = createSourceFile([
+        '@Component',
+        'export default class {',
+        '  myMethod() {',
+        '    return \'\';',
+        '  }',
+        '}',
+      ].join('\n'));
+
+      const migratedFile = await migrateFile(project, sourceFile);
+      expect(migratedFile.getText())
+        .toBe([
+          'import { defineComponent } from \'~/lib/helper/fallback-composition-api\';\n',
+          'export default defineComponent({',
+          '  methods: {',
+          '    myMethod() {',
+          '      return \'\';',
+          '    }',
+          '  }',
+          '})',
         ].join('\n'));
     });
   });
@@ -135,7 +161,7 @@ describe('migrateSingleFile()', () => {
   describe('when a file path is a .vue file', () => {
     let migrateFileSpy: jest.SpyInstance;
     const scriptSource = `'<script lang="ts">',
-'import Vue, { mounted } from "~/lib/helper/fallback-composition-api";',
+'import Vue, { mounted } from '~/lib/helper/fallback-composition-api';',
 '@Component',
 'export default class {}',
 '</script>',

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,8 +1,14 @@
 import { randomBytes } from 'crypto';
-import { Project } from 'ts-morph';
+import { IndentationText, Project, QuoteKind } from 'ts-morph';
 import { migrateFile } from '../migrator';
 
-export const project = new Project({ useInMemoryFileSystem: true });
+export const project = new Project({
+  useInMemoryFileSystem: true,
+  manipulationSettings: {
+    quoteKind: QuoteKind.Single,
+    indentationText: IndentationText.TwoSpaces,
+  },
+});
 export const createSourceFile = (content = undefined as string | undefined, ext = 'ts') => {
   const randomString = randomBytes(5).toString('hex');
   return project.createSourceFile(`./${randomString}.${ext}`, content);

--- a/src/__tests__/vue-class-component/migrator-component-decorator.test.ts
+++ b/src/__tests__/vue-class-component/migrator-component-decorator.test.ts
@@ -10,7 +10,7 @@ describe('@Component decorator', () => {
       `@Component({})
             class Test {}
             `,
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const Test = defineComponent({})
         `,
@@ -23,7 +23,7 @@ describe('@Component decorator', () => {
             class Test {}
             `,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const Test = defineComponent({})
         `,
@@ -37,7 +37,7 @@ describe('@Component decorator', () => {
             })
             export default class Test {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 mixins: [A,B,C]
@@ -52,7 +52,7 @@ describe('@Component decorator', () => {
             })
             export default class Test extends AnotherClass {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 mixins: [A,B,C],
@@ -89,7 +89,7 @@ describe('@Component decorator', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const beforeCreate = () => {};
             export default defineComponent({

--- a/src/__tests__/vue-class-component/migrator-data.test.ts
+++ b/src/__tests__/vue-class-component/migrator-data.test.ts
@@ -47,7 +47,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data: () => { return { a: 1 }; }
@@ -62,7 +62,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() { return { a: 1 }; }
@@ -82,7 +82,7 @@ describe('Data Property Migration', () => {
                 })
                 export default class Test extends Vue {}`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -106,7 +106,7 @@ describe('Data Property Migration', () => {
                     };
                 }`,
         // Throws
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -130,7 +130,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -167,7 +167,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -201,7 +201,7 @@ describe('Data Property Migration', () => {
                     myProp3 = false;
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {
@@ -239,7 +239,7 @@ describe('Data Property Migration', () => {
                     };
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     data() {

--- a/src/__tests__/vue-class-component/migrator-getter-setter.test.ts
+++ b/src/__tests__/vue-class-component/migrator-getter-setter.test.ts
@@ -15,7 +15,7 @@ describe('Data Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -38,7 +38,7 @@ describe('Data Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -66,7 +66,7 @@ describe('Data Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-class-component/migrator-methods.test.ts
+++ b/src/__tests__/vue-class-component/migrator-methods.test.ts
@@ -15,7 +15,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     created() {
@@ -37,7 +37,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     created() {
@@ -61,7 +61,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -84,7 +84,7 @@ describe('Methods Property Migration', () => {
                       }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -112,7 +112,7 @@ describe('Methods Property Migration', () => {
                     }
                 }`,
         // Results
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-class-component/migrator-mixins.test.ts
+++ b/src/__tests__/vue-class-component/migrator-mixins.test.ts
@@ -10,7 +10,7 @@ describe('Component extends', () => {
       `@Component
             export default class Test extends AnotherTest {}`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 extends: AnotherTest
@@ -23,7 +23,7 @@ describe('Component extends', () => {
       `@Component
             export default class Test extends AnotherTest {}`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 extends: AnotherTest

--- a/src/__tests__/vue-class-component/migrator-props.test.ts
+++ b/src/__tests__/vue-class-component/migrator-props.test.ts
@@ -17,7 +17,7 @@ describe('Component props', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             const props = {
                 test: 1
@@ -44,7 +44,7 @@ describe('Component props', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 props: {
@@ -67,7 +67,7 @@ describe('Component props', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 name: "test",

--- a/src/__tests__/vue-class-component/watch.test.ts
+++ b/src/__tests__/vue-class-component/watch.test.ts
@@ -21,7 +21,7 @@ describe('Component watch', () => {
             export default class Test extends Vue {}`,
 
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 watch: {
@@ -45,7 +45,7 @@ describe('Component watch', () => {
             })
             export default class Test extends Vue {}`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
             export default defineComponent({
                 name: "test",

--- a/src/__tests__/vue-property-decorator/model.test.ts
+++ b/src/__tests__/vue-property-decorator/model.test.ts
@@ -13,7 +13,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {
@@ -37,7 +37,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {
@@ -61,7 +61,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {
@@ -85,7 +85,7 @@ describe('@Model decorator', () => {
                     checked: boolean;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     model: {

--- a/src/__tests__/vue-property-decorator/modelSync.test.ts
+++ b/src/__tests__/vue-property-decorator/modelSync.test.ts
@@ -13,7 +13,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!
         }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -47,7 +47,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -81,7 +81,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: MyCheckedValue
         }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -115,7 +115,7 @@ describe('@ModelSync decorator', () => {
         readonly checkedValue!: boolean
       }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
         export default defineComponent({
           model: {
@@ -149,7 +149,7 @@ describe('@ModelSync decorator', () => {
             readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
         export default defineComponent({
           model: {
@@ -183,7 +183,7 @@ describe('@ModelSync decorator', () => {
             readonly checkedValue!: boolean
         }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
         export default defineComponent({
             model: {

--- a/src/__tests__/vue-property-decorator/propSync.test.ts
+++ b/src/__tests__/vue-property-decorator/propSync.test.ts
@@ -13,7 +13,7 @@ describe('@PropSync decorator', () => {
             syncedName;
         }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
     
         export default defineComponent({
             props: {
@@ -43,7 +43,7 @@ describe('@PropSync decorator', () => {
                         syncedName: string;
                     }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                     export default defineComponent({
                         props: {
@@ -73,7 +73,7 @@ describe('@PropSync decorator', () => {
                       syncedName: string | boolean;
                   }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
   
                   export default defineComponent({
                       props: {
@@ -103,7 +103,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -133,7 +133,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -163,7 +163,7 @@ describe('@PropSync decorator', () => {
                     syncedName: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/props.test.ts
+++ b/src/__tests__/vue-property-decorator/props.test.ts
@@ -14,7 +14,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -43,7 +43,7 @@ describe('@Prop decorator', () => {
                       permissions!: CommentPermissions;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -78,7 +78,7 @@ describe('@Prop decorator', () => {
                     checkId: string;            
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -104,7 +104,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -124,7 +124,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Result
-      `import { defineComponent, PropType } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -147,7 +147,7 @@ describe('@Prop decorator', () => {
                   @Prop([String, Boolean]) readonly propC: string | boolean | undefined
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -173,7 +173,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -191,7 +191,7 @@ describe('@Prop decorator', () => {
                     checkId: string;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -209,7 +209,7 @@ describe('@Prop decorator', () => {
                     checkId;
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {

--- a/src/__tests__/vue-property-decorator/refs.test.ts
+++ b/src/__tests__/vue-property-decorator/refs.test.ts
@@ -13,7 +13,7 @@ describe('@Ref', () => {
                     @Ref() readonly anotherComponent!: AnotherComponent
                 }`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -36,7 +36,7 @@ describe('@Ref', () => {
                     readonly defaultInput!: HTMLInputElement;                  
                 }`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -59,7 +59,7 @@ describe('@Ref', () => {
                     readonly defaultInput!: HTMLInputElement;                  
                 }`,
         // Result
-        `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+        `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vue-property-decorator/watch.test.ts
+++ b/src/__tests__/vue-property-decorator/watch.test.ts
@@ -13,7 +13,7 @@ describe('@Watch decorator', () => {
                     onChildChanged(val: string) { console.log("onChildChanged"); }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -40,7 +40,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -68,7 +68,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {
@@ -99,7 +99,7 @@ describe('@Watch decorator', () => {
                     }
                 }`,
       // Result
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     watch: {

--- a/src/__tests__/vuex/action.test.ts
+++ b/src/__tests__/vuex/action.test.ts
@@ -13,7 +13,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -33,7 +33,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -53,7 +53,7 @@ describe('Vuex @Action', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -73,7 +73,7 @@ describe('Vuex @Action', () => {
                     reload: (p1: string, p2, p3: number) => number;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {

--- a/src/__tests__/vuex/getter.test.ts
+++ b/src/__tests__/vuex/getter.test.ts
@@ -12,7 +12,7 @@ describe('Vuex @Getter', () => {
                     @Getter bar: string | null;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -32,7 +32,7 @@ describe('Vuex @Getter', () => {
                     getItemById!;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {
@@ -52,7 +52,7 @@ describe('Vuex @Getter', () => {
                     getItemById!;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     computed: {

--- a/src/__tests__/vuex/mutation.test.ts
+++ b/src/__tests__/vuex/mutation.test.ts
@@ -13,7 +13,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -33,7 +33,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -53,7 +53,7 @@ describe('Vuex @Mutation', () => {
                     reload: any;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {
@@ -73,7 +73,7 @@ describe('Vuex @Mutation', () => {
                     reload: (p1: string, p2, p3: number) => number;
                 }`,
       // Results
-      `import { defineComponent } from "~/lib/helper/fallback-composition-api";
+      `import { defineComponent } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     methods: {

--- a/src/migrator/migrator.ts
+++ b/src/migrator/migrator.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import {
+  IndentationText,
   Project,
+  QuoteKind,
   SourceFile,
 } from 'ts-morph';
 import logger from './logger';
@@ -91,9 +93,16 @@ const migrateEachFile = (
   return filesToMigrate.map((sourceFile) => resolveFileMigration(sourceFile, project));
 };
 
+const createProject = () => new Project({
+  manipulationSettings: {
+    quoteKind: QuoteKind.Single,
+    indentationText: IndentationText.TwoSpaces,
+  },
+});
+
 export const migrateDirectory = async (directoryPath: string, toSFC: boolean) => {
   const directoryToMigrate = path.join(process.cwd(), directoryPath);
-  const project = new Project({});
+  const project = createProject();
 
   project.addSourceFilesAtPaths(`${directoryToMigrate}/**/*.(ts|vue|scss)`)
     .filter((sourceFile) => !['.vue', '.ts'].includes(sourceFile.getExtension())
@@ -140,7 +149,7 @@ export const migrateSingleFile = async (filePath: string, toSFC: boolean): Promi
   }
 
   const fileToMigrate = path.join(process.cwd(), filePath);
-  const project = new Project({});
+  const project = createProject();
   project.addSourceFileAtPath(fileToMigrate);
   const sourceFiles = project.getSourceFiles();
 


### PR DESCRIPTION
# Overview

Modify default code style to

- single quotation
- 2 spaces indentation

## Note

`ts-morph` cannot remove semicolons of line ends: https://github.com/dsherret/ts-morph/issues/1200

To format this style, use code formatter like eslint.
