### PR TITLE
chore: import PropType by only type import

### DIFF
--- a/src/__tests__/vue-property-decorator/modelSync.test.ts
+++ b/src/__tests__/vue-property-decorator/modelSync.test.ts
@@ -13,7 +13,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!
         }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {
@@ -81,7 +81,7 @@ describe('@ModelSync decorator', () => {
           readonly checkedValue!: MyCheckedValue
         }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
   
         export default defineComponent({
           model: {

--- a/src/__tests__/vue-property-decorator/propSync.test.ts
+++ b/src/__tests__/vue-property-decorator/propSync.test.ts
@@ -13,7 +13,7 @@ describe('@PropSync decorator', () => {
             syncedName;
         }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
     
         export default defineComponent({
             props: {
@@ -73,7 +73,7 @@ describe('@PropSync decorator', () => {
                       syncedName: string | boolean;
                   }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
   
                   export default defineComponent({
                       props: {

--- a/src/__tests__/vue-property-decorator/props.test.ts
+++ b/src/__tests__/vue-property-decorator/props.test.ts
@@ -14,7 +14,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {
@@ -104,7 +104,7 @@ describe('@Prop decorator', () => {
                     
                 }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
     
                 export default defineComponent({
                     props: {
@@ -124,7 +124,7 @@ describe('@Prop decorator', () => {
                     checkId: MyCheckId;
                 }`,
       // Result
-      `import { defineComponent, PropType } from '~/lib/helper/fallback-composition-api';
+      `import { defineComponent, type PropType } from '~/lib/helper/fallback-composition-api';
 
                 export default defineComponent({
                     props: {

--- a/src/migrator/migratorManager.ts
+++ b/src/migrator/migratorManager.ts
@@ -182,7 +182,7 @@ export default class MigrationManager {
       .getImportDeclaration((imp) => imp.getModuleSpecifierValue() === module);
     if (!importDeclaration?.getNamedImports()
       .some((imp) => imp.getText() === namedImport)) {
-      importDeclaration?.addNamedImport('PropType');
+      importDeclaration?.addNamedImport({ name: 'PropType', isTypeOnly: true });
     }
   }
 


### PR DESCRIPTION
# Overview

When props with custom definition migrated,  import `PropType` by only type import.

## What's changed

- [x] import `PropType` by only type import

